### PR TITLE
Fix freezing the UE editor when quitting game mode after capturing (Linux).

### DIFF
--- a/Source/Plugins/NVSceneCapturer/Source/NVSceneCapturer/Private/NVImageExporter.cpp
+++ b/Source/Plugins/NVSceneCapturer/Source/NVSceneCapturer/Private/NVImageExporter.cpp
@@ -424,7 +424,6 @@ void FNVImageExporter_Thread::Stop()
     {
         // Trigger the event so the thread doesn't wait anymore
         HavePendingImageEvent->Trigger();
-        HavePendingImageEvent->Reset();
     }
 }
 


### PR DESCRIPTION
Hey there,

I was using the project on Ubuntu 18.04 with the UnrealEngine 4.21.3 built from source.
I could use the project according to the documentation without problems. But when quitting the game mode after recording data, the editor would freeze.

It was locking in the `FNVImageExporter_Thread::Stop` on the `Thread->Kill(true);` statement and therefore probably on `HavePendingImageEvent->Wait();` 
Not resetting the `HavePendingImageEvent` when stopping the thread fixed the problem.

I don't know if this was also a problem on Windows or Mac neither if this change introduces a problem on these platforms. Yet, "it worked on my machine".

Cheers,
Stefan